### PR TITLE
NGPVAN initial reply canvass result

### DIFF
--- a/src/extensions/message-handlers/ngpvan/index.js
+++ b/src/extensions/message-handlers/ngpvan/index.js
@@ -2,6 +2,7 @@ import { getConfig } from "../../../server/api/lib/config";
 const Van = require("../../../extensions/action-handlers/ngpvan-action");
 
 import { getActionChoiceData } from "../../../extensions/action-handlers";
+import { cacheableData } from "../../../server/models";
 
 export const DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT = "Texted";
 
@@ -31,16 +32,40 @@ export const postMessageSave = async ({ contact, organization }) => {
     return {};
   }
 
-  if (contact.message_status !== "needsMessage") {
-    return {};
+  const initialReplyCanvassResult = getConfig(
+    "NGP_VAN_INITIAL_REPLY_CANVASS_RESULT",
+    organization
+  );
+
+  let canvassResult;
+  if (contact.message_status === "needsMessage") {
+    canvassResult =
+      getConfig("NGP_VAN_INITIAL_TEXT_CANVASS_RESULT", organization) ||
+      DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT;
+  } else if (
+    initialReplyCanvassResult &&
+    contact.message_status === "needsResponse"
+  ) {
+    const messages =
+      (await cacheableData.message.query({ campaignContactId: contact.id })) ||
+      [];
+
+    // First message not from the contact will be initial text, the second is the initial reply since the user can only send one initial text.
+    if (messages.filter(m => !m.is_from_contact).length === 2) {
+      console.log({ initialReplyCanvassResult });
+      canvassResult = initialReplyCanvassResult;
+    }
   }
 
-  const clientChoiceData = await getActionChoiceData(Van, organization);
-  const initialTextResult =
-    getConfig("NGP_VAN_INITIAL_TEXT_CANVASS_RESULT", organization) ||
-    DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT;
+  if (!canvassResult) return {};
 
-  const texted = clientChoiceData.find(ccd => ccd.name === initialTextResult);
+  const clientChoiceData = await getActionChoiceData(
+    Van,
+    organization,
+    campaign
+  );
+
+  const texted = clientChoiceData.find(ccd => ccd.name === canvassResult);
   const body = JSON.parse(texted.details);
 
   return Van.postCanvassResponse(contact, organization, body)

--- a/src/extensions/message-handlers/ngpvan/index.js
+++ b/src/extensions/message-handlers/ngpvan/index.js
@@ -52,7 +52,6 @@ export const postMessageSave = async ({ contact, organization }) => {
 
     // First message not from the contact will be initial text, the second is the initial reply since the user can only send one initial text.
     if (messages.filter(m => !m.is_from_contact).length === 2) {
-      console.log({ initialReplyCanvassResult });
       canvassResult = initialReplyCanvassResult;
     }
   }


### PR DESCRIPTION
## Description

We already had a message handler for NGP VAN that would mark the contact as "Texted" on the first message. But, we also wanted the ability to update that value to "Canvassed" when they responded. We have elsewhere added the ability to add actions to Canned Responses, which allows canvass results to be applied per canned response. And the ability already existed for questions. But, for freeform texts, we still wanted the data to flow back into VAN. So, we're adding the 
NGP_VAN_INITIAL_REPLY_CANVASS_RESULT environment variable, which will set respondents to the new value. Also, we believe that when canvass results are applied, VAN wipes out any canvass results from the previous hour. So, a) if someone gets set to Texted and then an NGP_VAN_INITIAL_REPLY_CANVASS_RESULT is applied, the Texted value will be overridden by the new more up to date value and b) a question/response or canned response action will be applied after the NGP_VAN_INITIAL_REPLY_CANVASS_RESULT, so it will override it with the specific action value. 

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
