### PR TITLE
VAN Contacts Phone Id

### DIFF
--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -44,7 +44,8 @@ export const postCanvassResponse = async (contact, organization, body) => {
   try {
     const customFields = JSON.parse(contact.custom_fields || "{}");
     vanId = customFields.VanID || customFields.vanid;
-    contactsPhoneId = customFields.contactsPhoneId;
+    contactsPhoneId =
+      customFields.contactsPhoneId || customFields.contacts_phone_id;
   } catch (caughtException) {
     // eslint-disable-next-line no-console
     console.error(

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -39,9 +39,12 @@ export function clientChoiceDataCacheKey(organization) {
 
 export const postCanvassResponse = async (contact, organization, body) => {
   let vanId;
+  let contactsPhoneId;
+
   try {
     const customFields = JSON.parse(contact.custom_fields || "{}");
     vanId = customFields.VanID || customFields.vanid;
+    contactsPhoneId = customFields.contactsPhoneId;
   } catch (caughtException) {
     // eslint-disable-next-line no-console
     console.error(
@@ -56,6 +59,11 @@ export const postCanvassResponse = async (contact, organization, body) => {
       `Cannot sync results to van for campaign_contact ${contact.id}. No VanID in custom fields`
     );
     return {};
+  }
+
+  if (contactsPhoneId) {
+    body.canvassContext = body.canvassContext || {};
+    body.canvassContext.phoneId = contactsPhoneId;
   }
 
   const url = Van.makeUrl(`v4/people/${vanId}/canvassResponses`, organization);


### PR DESCRIPTION
## Description

For the NGPVAN Extension:  Some canvass results are specific to certain phone numbers, like Wrong Number or Disconnected. By supplying the ContactsPhoneId, we can see in the VAN database which numbers those are. Those data can be used later for filtering out bad numbers.

Docs: https://developers.ngpvan.com/van-api#people-post-people--personidtype---personid--canvassresponses

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
