### PR TITLE
Hotfix first campaign issues

### DIFF
--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -67,10 +67,13 @@ export class ContactController extends React.Component {
       window.ASSIGNMENT_CONTACTS_SIDEBAR &&
       this.props.messageStatusFilter !== "needsMessage"
     ) {
-      startIndex =
-        this.props.contacts.findIndex(
-          c => c.messageStatus === this.props.messageStatusFilter
-        ) || 0;
+      startIndex = this.props.contacts.findIndex(
+        c => c.messageStatus === this.props.messageStatusFilter
+      );
+
+      if (startIndex === -1) {
+        startIndex = 0;
+      }
     }
 
     this.updateCurrentContactIndex(startIndex);
@@ -539,13 +542,10 @@ export class ContactController extends React.Component {
     const { texter } = assignment || {};
     const contact = this.currentContact();
     const navigationToolbarChildren = this.getNavigationToolbarChildren();
-    const { finishedContactId, loading } = this.state;
-    const finished =
-      !contact ||
-      (navigationToolbarChildren &&
-        !navigationToolbarChildren.onNext &&
-        finishedContactId &&
-        Number(contact.id) === Number(finishedContactId));
+    const { loading } = this.state;
+    const finished = !contacts.some(
+      c => c.messageStatus === messageStatusFilter
+    );
     const settingsData = JSON.parse(
       (campaign &&
         campaign.texterUIConfig &&

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -446,7 +446,7 @@ const queries = {
           messageStatus: "needsMessage"
         }
       },
-      pollInterval: 5000
+      pollInterval: 30000
     })
   },
   organizationData: {

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -142,7 +142,9 @@ export class AssignmentTexterContact extends React.Component {
       console.error(e);
       this.props.setDisabled();
       this.setState({
-        snackbarError: "Something went wrong!"
+        snackbarError: e.message
+          ? e.message.replace("GraphQL error: ", "")
+          : "Something went wrong!"
       });
     }
   };
@@ -182,9 +184,7 @@ export class AssignmentTexterContact extends React.Component {
       return true;
     } catch (e) {
       this.handleSendMessageError(e);
-      setTimeout(() => {
-        this.props.onFinishContact(contact.id);
-      }, 750);
+      this.props.setDisabled(false);
 
       return false;
     }

--- a/src/extensions/message-handlers/profanity-tagger/index.js
+++ b/src/extensions/message-handlers/profanity-tagger/index.js
@@ -64,16 +64,6 @@ export const preMessageSave = async ({
       matches.length &&
       matches.every(m => m !== contact.first_name && m !== contact.last_name)
     ) {
-      // Object.assign(messageToSave, {
-      //   send_status: "ERROR",
-      //   error_code: -166
-      // });
-
-      // await r
-      //   .knex("campaign_contact")
-      //   .where("id", contact.id)
-      //   .update({ error_code: -166 });
-
       return {
         cancel: true,
         texterError:

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -135,9 +135,7 @@ export const sendMessage = async (
     texter: user
   });
   if (!saveResult.message) {
-    throw new GraphQLError(
-      `Message send error ${saveResult.texterError || ""}`
-    );
+    throw new GraphQLError(saveResult.texterError || "Message send error");
   }
   contact.message_status = saveResult.contactStatus;
 


### PR DESCRIPTION
# Fixes # (issue)

## Description

1. When going to a page for one message status, but none exist, it spins because there wasn't a -1 contact. Correcting to 0.
2. Finished should only occur when no messages exist for status.
3. Increase polling interval and query efficiency of stats for campaign stats page. Database was showing them as time consuming
4. Profanity tagger prevents send, displays a practical error
5. Doesn't move to next step when a detectable error occurs before send job is dispatched.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
